### PR TITLE
fix: removed set-gtid-purged=OFF

### DIFF
--- a/src/commands/mariadb
+++ b/src/commands/mariadb
@@ -43,7 +43,6 @@ mysqlDump() {
     --skip-comments \
     --skip-disable-keys \
     --skip-set-charset \
-    --set-gtid-purged=OFF \
     --no-tablespaces \
     "$MARIADB_DATABASE" | gzip -9 -c > /tmp/backup.sql.gz
   return "${PIPESTATUS[0]}"


### PR DESCRIPTION
This option does not exist on the mariaDB client, and you cannot have an actual MySQL client on alpine.
Giving up on this for now.