### PR TITLE
feat: add periodic moves to weekly, monthly, yearly dirs

### DIFF
--- a/charts/job-backup-db/Chart.yaml
+++ b/charts/job-backup-db/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.4"
+appVersion: "0.2.6"

--- a/charts/job-backup-db/templates/_helpers.tpl
+++ b/charts/job-backup-db/templates/_helpers.tpl
@@ -60,3 +60,22 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define path replacement helpers
+*/}}
+{{- define "job-backup-db.weeklyPath" -}}
+{{- $original := .Values.backup.remotePath -}}
+{{- $replaced := replace "/daily/" "/weekly/" $original -}}
+{{- $replaced -}}
+{{- end -}}
+{{- define "job-backup-db.monthlyPath" -}}
+{{- $original := .Values.backup.remotePath -}}
+{{- $replaced := replace "/daily/" "/monthly/" $original -}}
+{{- $replaced -}}
+{{- end -}}
+{{- define "job-backup-db.yearlyPath" -}}
+{{- $original := .Values.backup.remotePath -}}
+{{- $replaced := replace "/daily/" "/yearly/" $original -}}
+{{- $replaced -}}
+{{- end -}}

--- a/charts/job-backup-db/templates/monthly-moves.yaml
+++ b/charts/job-backup-db/templates/monthly-moves.yaml
@@ -1,0 +1,99 @@
+{{ if .Values.regularMoves.monthly.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "job-backup-db.fullname" . }}-mmv
+  labels:
+    {{- include "job-backup-db.labels" . | nindent 4 }}
+spec:
+  concurrencyPolicy: {{ .Values.cron.concurrencyPolicy }}
+  schedule: "{{ .Values.regularMoves.monthly.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cron.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cron.failedJobsHistoryLimit }}
+  suspend: {{ .Values.cron.suspend }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.cron.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "job-backup-db.labels" . | nindent 12 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: {{ .Values.restartPolicy }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.serviceAccountName }}
+          serviceAccountName: {{ . }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+          - name: {{ .Chart.Name }}
+            securityContext:
+              {{- toYaml .Values.securityContext | nindent 14 }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            args:
+              - mv
+              - {{ include "job-backup-db.weeklyPath" . }}
+              - {{ include "job-backup-db.monthlyPath" . }}
+            {{- with .Values.envFrom }}
+            envFrom:
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            env:
+            - name: BAGCLI_RETENTION_TIME
+              value: "{{ .Values.regularMoves.monthly.retentionTime }}"
+            {{- if .Values.regularMoves.monthly.webhookUrl }}
+            - name: BAGCLI_WEBHOOK_URL
+              value: {{ .Values.regularMoves.monthly.webhookUrl }}
+            {{- end }}
+            {{- if .Values.regularMoves.monthly.heartbeatUrl }}
+            - name: BAGCLI_HEARTBEAT_URL
+              value: {{ .Values.regularMoves.monthly.heartbeatUrl }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end -}}
+            {{- with .Values.resources -}}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            volumeMounts:
+            - mountPath: /home/job/.config/rclone
+              name: rclone
+            {{- if .Values.ephemeralVolume.enabled }}
+            - mountPath: {{ .Values.ephemeralVolume.mountPath }}
+              name: {{ .Values.ephemeralVolume.name }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: rclone
+            secret:
+              secretName: {{ .Values.backup.rclone.secret.name }}
+              items:
+              - key: {{ .Values.backup.rclone.secret.key }}
+                path: rclone.conf
+          {{- with .Values.volumes }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+{{- end -}}

--- a/charts/job-backup-db/templates/weekly-moves.yaml
+++ b/charts/job-backup-db/templates/weekly-moves.yaml
@@ -1,0 +1,99 @@
+{{ if .Values.regularMoves.weekly.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "job-backup-db.fullname" . }}-wmv
+  labels:
+    {{- include "job-backup-db.labels" . | nindent 4 }}
+spec:
+  concurrencyPolicy: {{ .Values.cron.concurrencyPolicy }}
+  schedule: "{{ .Values.regularMoves.weekly.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cron.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cron.failedJobsHistoryLimit }}
+  suspend: {{ .Values.cron.suspend }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.cron.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "job-backup-db.labels" . | nindent 12 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: {{ .Values.restartPolicy }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.serviceAccountName }}
+          serviceAccountName: {{ . }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+          - name: {{ .Chart.Name }}
+            securityContext:
+              {{- toYaml .Values.securityContext | nindent 14 }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            args:
+              - mv
+              - {{ .Values.backup.remotePath }}
+              - {{ include "job-backup-db.weeklyPath" . }}
+            {{- with .Values.envFrom }}
+            envFrom:
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            env:
+            - name: BAGCLI_RETENTION_TIME
+              value: "{{ .Values.regularMoves.weekly.retentionTime }}"
+            {{- if .Values.regularMoves.weekly.webhookUrl }}
+            - name: BAGCLI_WEBHOOK_URL
+              value: {{ .Values.regularMoves.weekly.webhookUrl }}
+            {{- end }}
+            {{- if .Values.regularMoves.weekly.heartbeatUrl }}
+            - name: BAGCLI_HEARTBEAT_URL
+              value: {{ .Values.regularMoves.weekly.heartbeatUrl }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end -}}
+            {{- with .Values.resources -}}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            volumeMounts:
+            - mountPath: /home/job/.config/rclone
+              name: rclone
+            {{- if .Values.ephemeralVolume.enabled }}
+            - mountPath: {{ .Values.ephemeralVolume.mountPath }}
+              name: {{ .Values.ephemeralVolume.name }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: rclone
+            secret:
+              secretName: {{ .Values.backup.rclone.secret.name }}
+              items:
+              - key: {{ .Values.backup.rclone.secret.key }}
+                path: rclone.conf
+          {{- with .Values.volumes }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+{{- end -}}

--- a/charts/job-backup-db/templates/yearly-moves.yaml
+++ b/charts/job-backup-db/templates/yearly-moves.yaml
@@ -1,0 +1,99 @@
+{{ if .Values.regularMoves.yearly.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "job-backup-db.fullname" . }}-ymv
+  labels:
+    {{- include "job-backup-db.labels" . | nindent 4 }}
+spec:
+  concurrencyPolicy: {{ .Values.cron.concurrencyPolicy }}
+  schedule: "{{ .Values.regularMoves.yearly.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cron.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cron.failedJobsHistoryLimit }}
+  suspend: {{ .Values.cron.suspend }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.cron.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "job-backup-db.labels" . | nindent 12 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: {{ .Values.restartPolicy }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.serviceAccountName }}
+          serviceAccountName: {{ . }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+          - name: {{ .Chart.Name }}
+            securityContext:
+              {{- toYaml .Values.securityContext | nindent 14 }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            args:
+              - mv
+              - {{ include "job-backup-db.monthlyPath" . }}
+              - {{ include "job-backup-db.yearlyPath" . }}
+            {{- with .Values.envFrom }}
+            envFrom:
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            env:
+            - name: BAGCLI_RETENTION_TIME
+              value: "{{ .Values.regularMoves.yearly.retentionTime }}"
+            {{- if .Values.regularMoves.yearly.webhookUrl }}
+            - name: BAGCLI_WEBHOOK_URL
+              value: {{ .Values.regularMoves.yearly.webhookUrl }}
+            {{- end }}
+            {{- if .Values.regularMoves.yearly.heartbeatUrl }}
+            - name: BAGCLI_HEARTBEAT_URL
+              value: {{ .Values.regularMoves.yearly.heartbeatUrl }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end -}}
+            {{- with .Values.resources -}}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            volumeMounts:
+            - mountPath: /home/job/.config/rclone
+              name: rclone
+            {{- if .Values.ephemeralVolume.enabled }}
+            - mountPath: {{ .Values.ephemeralVolume.mountPath }}
+              name: {{ .Values.ephemeralVolume.name }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+          - name: rclone
+            secret:
+              secretName: {{ .Values.backup.rclone.secret.name }}
+              items:
+              - key: {{ .Values.backup.rclone.secret.key }}
+                path: rclone.conf
+          {{- with .Values.volumes }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+{{- end -}}

--- a/charts/job-backup-db/values.yaml
+++ b/charts/job-backup-db/values.yaml
@@ -6,6 +6,7 @@ cron:
   suspend: false
   concurrencyPolicy: Forbid
   backoffLimit: 1
+
 restartPolicy: Never
 image:
   repository: skyloud/job-backup-db
@@ -48,7 +49,28 @@ backup:
     secret:
       name: rclone-config
       key: rclone.conf
-    
+
+# Moves the oldest daily to weekly,
+regularMoves:
+  weekly:
+    enabled: false
+    schedule: "0 3 * * 0"
+    retentionTime: "23d"
+    heartbeatUrl: ""
+    webhookUrl: ""
+  monthly:
+    enabled: false
+    schedule: "0 4 1 * *"
+    retentionTime: "335d"
+    heartbeatUrl: ""
+    webhookUrl: ""
+  yearly:
+    enabled: false
+    schedule: "0 5 31 12 *"
+    retentionTime: "3650d"
+    heartbeatUrl: ""
+    webhookUrl: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -57,7 +79,8 @@ podLabels: {}
 podSecurityContext:
   fsGroup: 1010
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -65,7 +88,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -76,7 +100,6 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/main.sh
+++ b/main.sh
@@ -15,6 +15,7 @@ Commands:
   mariadb   Mariadb dump
   mongodb MongoDB dump
   postgres_dumpall Posgres dumpall
+  mv        Move a dump elsewhere
   *         Help
 "
   exit 1
@@ -35,6 +36,9 @@ case "$1" in
     ;;
   mongodb|mongo)
     "$BAGCLI_WORKDIR/commands/mongodb"
+    ;;
+  mv)
+    "$BAGCLI_WORKDIR/commands/mv" "$2" "$3"
     ;;
   *)
     cli_help

--- a/src/commands/mv
+++ b/src/commands/mv
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -e
+set +o pipefail
+. "$BAGCLI_WORKDIR/common"
+
+cli_help_deploy() {
+  echo "
+Command: mv
+Desc: Oldest dump from olddir is moved to newdir.
+Usage:
+  mv olddir newdir"
+  exit 1
+}
+
+[ -z "$1" ] && cli_help_deploy
+[ -z "$2" ] && cli_help_deploy
+
+export SOURCE_REMOTE_PATH="$1"
+export TARGET_REMOTE_PATH="$2"
+
+cli_log "Moving oldest dump from $SOURCE_REMOTE_PATH to $TARGET_REMOTE_PATH BEGIN"
+
+removeOldBackup() {
+  cli_log "Removing backups older than $BAGCLI_RETENTION_TIME"
+  rclone_delete --min-age "$BAGCLI_RETENTION_TIME" backup:"$TARGET_REMOTE_PATH"/ || true
+}
+
+checkOldestDump() {
+  cli_log "Looking for oldest dump in $SOURCE_REMOTE_PATH"
+  local oldest_file=$(rclone_cmd lsl "$SOURCE_REMOTE_PATH" | sort -k2 | head -n 1 | awk '{print $4}')
+  echo "$oldest_file"
+}
+
+moveOnS3() {
+  local file_name="$1"
+  cli_log "Moving dump"
+  rclone_cp backup:"$SOURCE_REMOTE_PATH"/$file_name backup:"$BAGCLI_REMOTE_PATH"/$file_name
+  return "${PIPESTATUS[0]}"
+}
+
+checkSucceed() {
+  if [ $? -gt 0 ]; then
+    cli_log "[KO] $?"
+    exit "$1"
+  fi
+}
+
+main(){
+  removeOldBackup
+  checkSucceed "removing old backups failed"
+
+  oldest_file=$(checkOldestDump)
+
+  moveOnS3 "$oldest_file"
+  checkSucceed "Moving backup on the s3 bucket failed"
+
+  heartbeatPing
+  cli_log "job succeed"
+
+  postToWebhook
+  cli_log "post to WebHook succeed"
+}
+
+main


### PR DESCRIPTION
# New functionalities

1. The docker image has a new command `mv` that moves the oldest file from path A to path B.
2. The chart allows to define 3 more cronjobs launching the image with the mv command. They are disabled by default (non breaking). Set them using the new values:

```yaml
regularMoves:
  weekly:
    enabled: false
    schedule: "0 3 * * 0"
    retentionTime: "23d"
    heartbeatUrl: ""
    webhookUrl: ""
  monthly:
    enabled: false
    schedule: "0 4 1 * *"
    retentionTime: "335d"
    heartbeatUrl: ""
    webhookUrl: ""
  yearly:
    enabled: false
    schedule: "0 5 31 12 *"
    retentionTime: "3650d"
    heartbeatUrl: ""
    webhookUrl: ""
```

Before moving the dump, the mv command also checks for expiration of the dumps in path B, allowing them to have a different retention time than A.
Each cronjob also has the ability to ping its own heartbeat and a webHook URL.